### PR TITLE
Log backtrace of unhandled exceptions

### DIFF
--- a/solaredge.py
+++ b/solaredge.py
@@ -98,7 +98,7 @@ async def write_to_influx(dbhost, dbport, period, dbname='solaredge'):
         except IOError as e:
             logger.error(f'I/O exception during operation: {e}')
         except Exception as e:
-            logger.error(f'Unhandled exception: {e}')
+            logger.exception(f'Unhandled exception: {e}')
 
         await asyncio.sleep(period)
 


### PR DESCRIPTION
When an unhandled exception occurs in the main loop, include the
backtrace in the log so you can identify which line of code triggered
it.
