### PR TITLE
Fix register parsing for latest SolarEdge SunSpec ModBus implementation

### DIFF
--- a/solaredge.py
+++ b/solaredge.py
@@ -84,16 +84,16 @@ async def write_to_influx(dbhost, dbport, period, dbname="solaredge"):
                 datapoint["fields"]["AC Power output"] = decode_value(
                     data.decode_16bit_int(), scalefactor
                 )
-                data.skip_bytes(24)
+                data.skip_bytes(22)
                 scalefactor = 10 ** data.decode_16bit_int()
                 data.skip_bytes(-6)
                 # register 40094
                 datapoint["fields"]["AC Lifetimeproduction"] = decode_value(
                     data.decode_32bit_uint(), scalefactor
                 )
-                data.skip_bytes(2)
+                data.skip_bytes(4)
                 scalefactor = 10 ** data.decode_16bit_int()
-                data.skip_bytes(-2)
+                data.skip_bytes(-4)
                 # register 40097
                 datapoint["fields"]["DC Current"] = decode_value(
                     data.decode_16bit_uint() * scalefactor


### PR DESCRIPTION
On a new SE5000H, I encountered issue #2. I found that the register
parsing implementation doesn't match what's listed in the [SolarEdge technical
spec](https://www.solaredge.com/sites/default/files/sunspec-implementation-technical-note.pdf) for their SunSpec ModBus implementation.

The code was seeking too far forward, and from that point on it was
reading a mix of 2 registers and trying to interpret as scaling factors
or measurements. This caused seemingly random, extremely large values
that triggered the "int too large to convert to float". The issue, at
least for my unit, was not with the field that could not be parsed.

With these new values, all measurements supported by my unit are
reporting values that match the SolarEdge monitoring website.

I'm not positive if this is specific to only some units, but the
technical note does not indicate they use different registers for
different inverter models.
