### PR TITLE
Update and pin external dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.10.13-alpine
 
 MAINTAINER alberink@gmail.com
 
@@ -9,9 +9,7 @@ ENV INVERTERPORT=502
 ENV UNITID=1
 
 ADD requirements.txt /
-RUN apk add --no-cache --update alpine-sdk && \
-    pip3 install -r /requirements.txt && \
-    apk del alpine-sdk
+RUN pip3 install -r /requirements.txt
 
 ADD solaredge.py /
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aioinflux >= 0.3.3
-pymodbusTCP >= 0.1.6
-pymodbus
+aioinflux == 0.9.0
+pymodbusTCP == 0.2.1
+pymodbus==3.5.0

--- a/solaredge.py
+++ b/solaredge.py
@@ -39,7 +39,9 @@ async def write_to_influx(dbhost, dbport, period, dbname='solaredge'):
             reg_block = client.read_holding_registers(40069, 38)
             if reg_block:
                 # print(reg_block)
-                data = BinaryPayloadDecoder.fromRegisters(reg_block, byteorder=Endian.Big, wordorder=Endian.Big)
+                data = BinaryPayloadDecoder.fromRegisters(
+                    reg_block, byteorder=Endian.BIG, wordorder=Endian.BIG
+                )
                 data.skip_bytes(12)
                 scalefactor = 10**data.decode_16bit_int()
                 data.skip_bytes(-10)


### PR DESCRIPTION
Pin the following versions, to avoid surprises when building or installing:

* Base Dockerfile and Python version. Update from 3.6 to 3.10.13 to support latest pymodbus
* Update pymodbus and use new enum name

I ran into issues during a re-installation, because the build pulled in the latest pymodbus that had breaking API changes.