### PR TITLE
Update error handling for compatibility with latest pyModbusTCP

### DIFF
--- a/solaredge.py
+++ b/solaredge.py
@@ -122,15 +122,10 @@ async def write_to_influx(dbhost, dbport, period, dbname="solaredge"):
 
                 await solar_client.write(datapoint)
             else:
-                # Error during data receive
-                if client.last_error() == 2:
-                    logger.error(
-                        f"Failed to connect to SolarEdge inverter {client.host()}!"
-                    )
-                elif client.last_error() == 3 or client.last_error() == 4:
-                    logger.error("Send or receive error!")
-                elif client.last_error() == 5:
-                    logger.error("Timeout during send or receive operation!")
+                logger.error(
+                    "Failed while connecting or receiving data from "
+                    f"SolarEdge inverter {client.host}: {client.last_error_as_txt}"
+                )
         except InfluxDBWriteError as e:
             logger.error(f"Failed to write to InfluxDb: {e}")
         except IOError as e:


### PR DESCRIPTION
The newer version converted the `last_error` method to a `@property`. There's also a new helper `@property` that converts error codes to strings for us, so I just opted to use that.